### PR TITLE
Integrate local material design icons through sprockets and other style changes

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,6 @@
-activate :sprockets
+activate :sprockets do |c|
+  c.expose_middleman_helpers = true
+end
 
 ###
 # Page options, layouts, aliases and proxies

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/garyanewsome/savvysoftworks_middleman#readme",
   "dependencies": {
     "cornerstone-event-components": "git+ssh://git@bitbucket.org/thecodeavengers/inlinecomponents.git#pks/jsonp_all_the_things",
+    "material-design-icons": "^2.2.3",
     "moment": "^2.14.1"
   }
 }

--- a/source/_about.html.erb
+++ b/source/_about.html.erb
@@ -1,10 +1,10 @@
 <div class="about container" id="about">
-  <h4 class="center">About Us:</h4>
+  <h4 class="center section-title">About Us</h4>
   <div class="row">
     <div class="col s12 m6">
         <h5 class="center">SavvySoftWorks</h5>
         <p class="light">We develop world class software development teams and software by integrating our engineers in small / medium sized companies. By working alongside your engineers we can increase velocity and productivity while imparting industry best practices into your development process. Primarily we teach how to safely use OpenSource Software, improved code quality through low impact code reviews, and how to build reliable software using TDD. We can work with any major language and have serviced clients using RubyOnRails, Python, PHP, NodeJS, and various front end frameworks like AngularJS and ReactJS.</p>
-    </div> 
+    </div>
     <div class="col s12 m6">
       <h5 class="center">Paul Scarrone</h5>
       <p class="light">When you have a set of skills its hard to escape using them. At SavvySoftWorks we do not directly solicit work but that work comes to us anyways.<br><br>

--- a/source/_current_clients.html.erb
+++ b/source/_current_clients.html.erb
@@ -1,5 +1,5 @@
 <div class="current_clients container current" id="current_clients">
-  <h4>Current Clients</h4>
+  <h4 class="section-title">Current Clients</h4>
   <ul class="collapsible" data-collapsible="accordion">
     <li>
       <div class="collapsible-header active"><i class="material-icons">filter_drama</i>

--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="row header" id="top">
   <div class="logo col s12 m3 l9">
     <h1>SavvySoftWorks</h1>
-    <h4>Solving problems and growing your development team.</h4>
+    <h4>Building reliable software and expert development teams</h4>
   </div>
   <div class="col s12 m4 l3 container">
       <p>Paul Scarrone<br/>

--- a/source/_navbar.html.erb
+++ b/source/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav>
   <div class="nav-wrapper">
     <a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
-    <ul class="left hide-on-med-and-down">
+    <ul class="right hide-on-med-and-down">
       <li><a href="#about">About Us</a></li>
       <li><a href="#current_clients">Current Clients</a></li>
       <li><a href="#products">Products</a></li>

--- a/source/_products.html.erb
+++ b/source/_products.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col s12 m4">
       <div class="icon-block">
-        <h2 class="center"><i class="material-icons">group</i></h2>
+        <h2 class="center"><i class="material-icons md-48">group</i></h2>
         <h4 class="center">Growing Your Development Team</h4>
 
         <p class="light">We develop world class software development teams and software by integrating our engineers in small / medium sized companies. By working alongside your engineers we can increase velocity and productivity while imparting industry best practices into your development process. Primarily we teach how to safely use OpenSource Software, improved code quality through low impact code reviews, and how to build reliable software using TDD.</p>
@@ -12,8 +12,8 @@
 
     <div class="col s12 m4">
       <div class="icon-block">
-        <h2 class="center"><i class="material-icons">email</i></h2>
-        <h4 class="center">savvy_mailer</h4>
+        <h2 class="center"><i class="material-icons md-48">email</i></h2>
+        <h4 class="center">savvy_mailer<br/>&nbsp;</h4>
 
         <p class="light">Dynamically submit forms from static websites. Starting at $2 a month for unlimited submissions.</p>
       </div>
@@ -21,8 +21,8 @@
 
     <div class="col s12 m4">
       <div class="icon-block">
-        <h2 class="center brown-text"><i class="material-icons">settings</i></h2>
-        <h4 class="center">Coming Soon...</h4>
+        <h2 class="center"><i class="material-icons md-48">settings</i></h2>
+        <h4 class="center">Coming Soon...<br/>&nbsp;</h4>
 
         <p class="light">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,6 @@
 <%= partial "parallax" %>
 
-<div class="row col s12 slide_container">
+<div class="has-shadow row col s12 slide_container">
   <ul class="rslides">
     <li>
       <a href="#about">
@@ -28,22 +28,21 @@
     </li>
   </ul>
 </div>
-<ul class"rslider_tab"></ul>
 
 <%= partial "parallax" %>
-<div class="row col s12">
+<div class="has-shadow row col s12">
   <%= partial "about" %>
 </div>
 <%= partial "parallax" %>
-<div class="row col s12">
+<div class="has-shadow row col s12">
   <%= partial "current_clients" %>
 </div>
 <%= partial "parallax" %>
-<div class="row col s12">
+<div class="has-shadow row col s12">
   <%= partial "products" %>
 </div>
 <%= partial "parallax" %>
-<div class="row col s12">
+<div class="has-shadow row col s12">
   <%= partial "contact" %>
 </div>
 <%= partial "parallax" %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,16 +5,16 @@
   <meta name="keywords" content="SavvySoftWorks, Paul Scarrone, software, web, applications, apps, websites, webpages, problem, solving, solutions, custom, growth, education, development, programming, Ruby, Rails, Laravel, JavaScript, AngularJS, ReactJS, Node">
   <title>SavvySoftWorks</title>
   <!--Import Google Icon Font-->
-  <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
   <!--Import responsiveslides.css-->
   <%= stylesheet_link_tag 'responsiveslides' %>
   <!--Import materialize.css-->
-  <%= stylesheet_link_tag 'styles' %>
+  <%= stylesheet_link_tag 'application' %>
   <!--Let browser know website is optimized for mobile-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <link rel="icon" type="image/x-icon" href="images/SSWfav.ico" />
 
-  
+
 
 </head>
 
@@ -24,7 +24,7 @@
     <%= yield %>
     <%= partial "footer" %>
 
-    <a href="#top" class="btn returntotop" style="bottom: 16px; right: 16px;"><i class="material-icons left">navigation</i>return to top</a>     
+    <a href="#top" class="btn returntotop" style="bottom: 16px; right: 16px;"><i class="material-icons left">navigation</i>return to top</a>
 
   <%= javascript_include_tag 'all' %>
   <%= javascript_include_tag 'responsiveslides' %>

--- a/source/stylesheets/application.css
+++ b/source/stylesheets/application.css
@@ -1,0 +1,18 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any styles
+ * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
+ * file per style scope.
+ *
+ *= link material-design-icons/iconfont/MaterialIcons-Regular.woff2
+ *= link material-design-icons/iconfont/MaterialIcons-Regular.eot
+ *= link material-design-icons/iconfont/MaterialIcons-Regular.woff
+ *= link material-design-icons/iconfont/MaterialIcons-Regular.ttf
+ *= require styles.css
+ */

--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -1,5 +1,8 @@
 @charset "UTF-8";
 
+@import url(https://fonts.googleapis.com/css?family=Audiowide);
+@import url(https://fonts.googleapis.com/css?family=Oxygen:400,700);
+
 // Mixins
 // @import "components/prefixer";
 @import "materialize/components/mixins";
@@ -39,6 +42,90 @@
 @import "materialize/components/date_picker/default.date";
 @import "materialize/components/date_picker/default.time";
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(../assets/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: local('Material Icons'),
+       local('../assets/material-design-icons/iconfont/MaterialIcons-Regular'),
+       url(../assets/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../assets/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../assets/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;  /* Preferred icon size */
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
+
+  &.md-18{font-size: 18px;}
+  &.md-24{font-size: 24px;}
+  &.md-36{font-size: 36px;}
+  &.md-48{font-size: 48px;}
+}
+
+.has-shadow {
+  box-shadow: 0px 9px 7px 0px rgba(50, 50, 50, 0.6);
+  margin-bottom: 0;
+  padding-bottom: 20px;
+}
+
+.section-title {
+  font-family: 'Oxygen', cursive;
+}
+
+.parallax-container {
+  box-shadow: inset 0px -9px 7px 0px rgba(50, 50, 50, 0.6);
+}
+
+.nav-wrapper {
+  box-shadow: 0px 9px 7px 0px rgba(50, 50, 50, 0.6);
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.material-icons.md-18 {
+  font-size: 18px; }
+.material-icons.md-24 {
+  font-size: 24px; }
+.material-icons.md-36 {
+  font-size: 36px; }
+.material-icons.md-48 {
+  font-size: 48px; }
+
+.current_clients {
+  .collapsible-header {
+    font-weight: 700;
+  }
+  h5 {
+    color: #FCFEFC;
+  }
+}
+
 $body: #F5F5F5;
 $maintext: #000078;
 $footer: #FFFFFF;
@@ -54,14 +141,20 @@ body {
   color: $maintext;
 }
 
+.logo {
+  h1 {
+    font-family: Oxygen, cursive;
+  }
+}
+
 .container {
-  font-family: Ubuntu, "Trebuchet MS", Helvetica, sans-serif;
+  font-family: Oxygen, Ubuntu, "Trebuchet MS", Helvetica, sans-serif;
   padding: 8px;
   width: 80%;
 }
 
 .slide_container {
-  font-family: Ubuntu, "Trebuchet MS", Helvetica, sans-serif;
+  font-family: Oxygen, Ubuntu, "Trebuchet MS", Helvetica, sans-serif;
   padding: 8px;
   width: 100%;
 }
@@ -150,11 +243,11 @@ footer{
   font-weight: bold;
   }
 
-  .caption {
-    color: $maintext;
-    font-size: 2em;
-    text-align: center;
-  }
+.caption {
+  color: $maintext;
+  font-size: 2em;
+  text-align: center;
+}
 
 .current h5 {
   padding-top: 1em;


### PR DESCRIPTION
### What am I?

implements sprockets `link` attribute to assign assets from node_modules to the assets mount point.

Adds border-shadow around the content containers and replaced Ubuntu with oxygen font.

Moves Navigation to the right side

Fixes responsive bug with logo and contact info at middle break.
